### PR TITLE
Moved disclaimer dialog to new "Download" page

### DIFF
--- a/public/js/view/view.download.js
+++ b/public/js/view/view.download.js
@@ -1,0 +1,16 @@
+// When page ready
+$(document).ready(function(){
+
+  if($('#disclaimerWrapper').length != 0)
+  {
+    $.fancybox.open([
+    {
+      href : '#disclaimerWrapper',
+      closeBtn:false,
+      keys : {
+        close  : null
+      }
+    }]);
+  }
+});
+

--- a/public/js/view/view.index.js
+++ b/public/js/view/view.index.js
@@ -5,18 +5,6 @@ $(document).ready(function(){
     return confirm("You are about to be redirected to an archive version. The content may not be accurate.");
   })
   
-  if($('#disclaimerWrapper').length != 0)
-  {
-    $.fancybox.open([
-    {
-      href : '#disclaimerWrapper',
-      closeBtn:false,
-      keys : {
-        close  : null
-      }
-    }]);
-  }
-  
   $("#revisionSelector").change(function(){
     window.location.href = json.global.webroot+"/journal/view/"+$(this).val();
   })

--- a/views/view/download.phtml
+++ b/views/view/download.phtml
@@ -1,0 +1,64 @@
+<?php
+/*=========================================================================
+ *
+ *  Copyright OSHERA Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+$this->headScript()->appendFile($this->webroot . '/privateModules/journal/public/js/view/view.download.js');
+$this->headScript()->appendFile($this->webroot . '/privateModules/journal/public/js/lib/fancyapp/source/jquery.fancybox.pack.js');
+?>
+
+<LINK rel="stylesheet" type="text/css" href="<?php echo $this->webroot ?>/privateModules/journal/public/js/lib/fancyapp/source/jquery.fancybox.css">
+
+
+<div>
+  <h3>Download</h3>
+  <a href="<?php echo $this->webroot?>/journal/view/?revisionId=<?php echo $this->resource->getRevision()->getKey()?>">Back to article</a>
+  <br/>
+  <br/>
+  <ul>
+    <li><a href="<?php echo $this->webroot ?>/download?items=<?php echo $this->resource->getKey() ?>, <?php echo $this->resource->getRevision()->getRevision() ?>">Download All</a>
+      (<?php echo MidasLoader::loadComponent("Utility")->formatSize($this->resource->getSizebytes()); ?>)</li>
+    <?php
+    if($this->paper)
+      {
+      ?>
+    <li><a href="<?php echo $this->webroot ?>/download?bitstream=<?php echo $this->paper->getKey() ?>">Download Paper</a>
+    </li>
+    <?php
+      }
+      ?>
+  </ul>
+</div>
+
+<?php
+if($this->resource->getDisclaimer() != -1)
+  {
+  $disclaimer = MidasLoader::loadModel("Disclaimer", "journal")->load($this->resource->getDisclaimer());
+  if($disclaimer)
+    {
+    echo '<div id="disclaimerWrapper" style="display:none;width:700px;"><h4>Disclaimer</h4>';
+    echo "<pre>".$disclaimer->getDescription().'</pre>';
+    echo "<br>
+      <table style='width:140px;margin:auto;'>
+        <tbody><tr>
+           <td> <a href='#' onclick='$.fancybox.close();'>Agree</a></td>
+              <td>|</td>
+               <td><div align='center'><a href='".$this->webroot."/journal/view/?revisionId=".$this->resource->getRevision()->getKey()."'>Decline</a></div></td>
+          </tr>
+        </tbody></table>";
+    echo "</div>";
+    }
+  }

--- a/views/view/index.phtml
+++ b/views/view/index.phtml
@@ -17,7 +17,6 @@
  *
  *=========================================================================*/
 $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public/js/lib/jquery-share/jquery.share.js');
-$this->headScript()->appendFile($this->webroot . '/privateModules/journal/public/js/lib/fancyapp/source/jquery.fancybox.pack.js');
 $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public/js/view/view.index.js');
 
 $cssArray = Zend_Registry::get('notifier')->callback('CALLBACK_CORE_ITEM_VIEW_CSS', array('item' => $this->resource));
@@ -40,23 +39,14 @@ foreach ($cssArray as $module => $list)
 ?>
 <link type="text/css" href="<?php echo $this->webroot ?>/privateModules/journal/public/css/view/view.index.css" rel="stylesheet" />
 <link type="text/css" href="<?php echo $this->webroot ?>/privateModules/journal/public/js/lib/jquery-share/jquery.share.css" rel="stylesheet" />
-<LINK rel="stylesheet" type="text/css" href="<?php echo $this->webroot ?>/privateModules/journal/public/js/lib/fancyapp/source/jquery.fancybox.css">
 <div class="ContentWithRightPanel">
   <div class="Panel">
 
 
     <h4>Resources</h4>
     <ul>
-      <li><a href="<?php echo $this->webroot ?>/download?items=<?php echo $this->resource->getKey() ?>, <?php echo $this->resource->getRevision()->getRevision() ?>">Download All</a>
-        (<?php echo MidasLoader::loadComponent("Utility")->formatSize($this->resource->getSizebytes()); ?>)</li>
+      <?php echo "<li><a href='" . $this->webroot . "/journal/view/download?revisionId=" . $this->resource->getRevision()->getKey() . "'>Download</a></li>"; ?>
       <?php
-      if($this->paper)
-        {
-        ?>
-      <li><a href="<?php echo $this->webroot ?>/download?bitstream=<?php echo $this->paper->getKey() ?>">Download Paper</a>
-      </li>
-      <?php
-        }
       $github = $this->resource->getGithub();
       if(!empty($github))
         {
@@ -282,25 +272,3 @@ foreach ($cssArray as $module => $list)
     ?>
   </div>
 </div>
-
-
-<?php
-if($this->resource->getDisclaimer() != -1)
-  {
-  $disclaimer = MidasLoader::loadModel("Disclaimer", "journal")->load($this->resource->getDisclaimer());
-  if($disclaimer)
-    {
-    echo '<div id="disclaimerWrapper" style="display:none;width:700px;"><h4>Disclaimer</h4>';
-    echo "<pre>".$disclaimer->getDescription().'</pre>';
-    echo "<br>
-      <table style='width:140px;margin:auto;'>
-        <tbody><tr>
-           <td> <a href='#' onclick='$.fancybox.close();'>Agree</a></td>
-              <td>|</td>
-               <td><div align='center'><a href='".$this->webroot."/journal'>Decline</a></div></td>
-
-          </tr>
-        </tbody></table>";
-    echo "</div>";
-    }
-  }


### PR DESCRIPTION
This way, the disclaimer dialog won't appear each time an issue is viewed.

Not only was this annoying but currently Google is not able to crawl
the OTJ submission because of the Disclaimer popup.
