### PR TITLE
Fixed bug in text of updated submission email

### DIFF
--- a/views/email/updatedsubmission.phtml
+++ b/views/email/updatedsubmission.phtml
@@ -14,7 +14,7 @@
                 <div>
                   <br>
                   <p style="text-align:justify;text-justify:inter-word;">Hello,</p>
-                  <p style="text-align:justify;text-justify:inter-word;">A new submission has been updated in the OSEHRA Technical Journal.</p>
+                  <p style="text-align:justify;text-justify:inter-word;">A submission has been updated in the OSEHRA Technical Journal.</p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo $this->name ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo $this->description ?></p>


### PR DESCRIPTION
Should read: "A submission has been updated..."

instead of "A NEW submission has been updated..."
