### PR TITLE
Fixed the displayed Download size

### DIFF
--- a/views/view/download.phtml
+++ b/views/view/download.phtml
@@ -29,8 +29,16 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
   <br/>
   <br/>
   <ul>
+    <?php
+    $size = 0;
+    $bitstreams = $this->resource->getRevision()->getBitstreams();
+    foreach ($bitstreams as $bitstream)
+      {
+      $size += $bitstream->getSizebytes();
+      }
+    ?>
     <li><a href="<?php echo $this->webroot ?>/download?items=<?php echo $this->resource->getKey() ?>, <?php echo $this->resource->getRevision()->getRevision() ?>">Download All</a>
-      (<?php echo MidasLoader::loadComponent("Utility")->formatSize($this->resource->getSizebytes()); ?>)</li>
+      (<?php echo MidasLoader::loadComponent("Utility")->formatSize($size); ?>)</li>
     <?php
     if($this->paper)
       {


### PR DESCRIPTION
Previously, the size of the item was displayed. Instead, display the size of the revision (sum of the bitstream sizes).
