### PR TITLE
ENH: Update modal window configuration

### DIFF
--- a/public/js/submit/submit.index.js
+++ b/public/js/submit/submit.index.js
@@ -7,6 +7,9 @@ $(document).ready(function(){
     {
       href : '#licenseWrapper',
       closeBtn:false,
+      helpers: {
+        overlay: {closeClick: false}
+      },
       keys : {
         close  : null
       }

--- a/public/js/view/view.download.js
+++ b/public/js/view/view.download.js
@@ -7,6 +7,9 @@ $(document).ready(function(){
     {
       href : '#disclaimerWrapper',
       closeBtn:false,
+      helpers: {
+        overlay: {closeClick: false}
+      },
       keys : {
         close  : null
       }


### PR DESCRIPTION
Update the Fancybox modal window configuration used in the License and Disclaimer
windows. Currently, clicking on the "overlay" will cause the window to close, change it to only close on the clicking of the agree/disagree links.  
