### PR TITLE
Replace blank entry in submission type pulldown.

### DIFF
--- a/views/submit/index.phtml
+++ b/views/submit/index.phtml
@@ -124,7 +124,7 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
         <tr>
           <td>
             <select name="type" data-required="true">
-              <option value="<?php echo RESOURCE_TYPE_NOT_DEFINED ?>" <?php if ($this->resource->getType() == RESOURCE_TYPE_NOT_DEFINED) echo "selected"; ?>></option>
+              <option value="<?php echo RESOURCE_TYPE_NOT_DEFINED ?>" <?php if ($this->resource->getType() == RESOURCE_TYPE_NOT_DEFINED) echo "selected"; ?>>General</option>
               <option value="<?php echo RESOURCE_TYPE_SOFTWARE ?>" <?php if ($this->resource->getType() == RESOURCE_TYPE_SOFTWARE) echo "selected"; ?>>Software</option>
               <option value="<?php echo RESOURCE_TYPE_PLUGIN ?>" <?php if ($this->resource->getType() == RESOURCE_TYPE_PLUGIN) echo "selected"; ?>>Plugin</option>
               <option value="<?php echo RESOURCE_TYPE_PUBLICATION ?>" <?php if ($this->resource->getType() == RESOURCE_TYPE_PUBLICATION) echo "selected"; ?>>Publication</option>


### PR DESCRIPTION
Replace the blank entry in the type pulldown selection to read "General"
instead. A blank entry seemed to be contrary to the required status, even
though it was an acceptable answer.
