### PR TITLE
Fix review upload process

### DIFF
--- a/controllers/SubmitController.php
+++ b/controllers/SubmitController.php
@@ -191,7 +191,7 @@ class Reviewosehra_SubmitController extends Reviewosehra_AppController
 
     if(isset($returninfo[0]) && $returninfo[0]->size > 0 && isset($upload_handler->filepath) && file_exists($upload_handler->filepath))
       {
-      $userDao = MidasLoader::loadModel("Item")->load($this->userSession->Dao->getKey());
+      $userDao = $this->userSession->Dao;
       $userDao->setAdmin(1);
       $item = MidasLoader::loadComponent("Upload")->createUploadedItem($userDao, $upload_handler->filename,
                                 $upload_handler->filepath, $privateFolder);


### PR DESCRIPTION
Currently, the file upload process returns a 500 error when trying
to attach a file to a review question with the following error:

  Call to a member function setAdmin() on a non-object
  In /home/softhat/work/Midas3/privateModules/reviewosehra/controllers/SubmitController.php, line: 195

Remove the load of the key from the database and return simply the
userdao from the current session.
