### PR TITLE
Add second search to certification filter

### DIFF
--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -141,7 +141,7 @@ class Journal_ApiComponent extends AppComponent
             'rating' => (float)$rating['average'], 'type' => $item->getType(), 'logo' => $resourceDao->getLogo(),
             'id' => $item->getKey(), 'description' => htmlentities($item->getDescription(), ENT_COMPAT | ENT_HTML401, "UTF-8" ),
             'authors' => $authors, 'view' => $item->getView() ,'downloads' => $resourceDao->getDownload(), 'statistics' => $statistics,
-            'revisionId' => $resourceDao->getRevision()->getKey(), "isCertified" => $isCertified, 'revisionID' => $foundRevision, "certifiedLevel" => $level);
+            'revisionId' => $resourceDao->getRevision()->getKey(), "isCertified" => $isCertified, 'pastCertificationID' => $foundRevision, "certifiedLevel" => $level);
 
           $count++;
           }

--- a/models/dao/ResourceDao.php
+++ b/models/dao/ResourceDao.php
@@ -210,6 +210,17 @@ class Journal_ResourceDao extends ItemDao
     return $metadata->getValue();
     }
 
+  /** Get Certification level searching through every revision
+   *
+   * @return
+   */
+  function getAllCertificationLevel($level)
+    {
+    list($metadata,$revisionID) = $this->getAllMetaDataByQualifier("certification_level",$level);
+    if(!$metadata) return '';
+    return array($metadata->getValue(),$revisionID);
+    }
+
    /* Set Certification level
    * @param
    */
@@ -635,6 +646,44 @@ class Journal_ResourceDao extends ItemDao
     return $this->_getMetaDataByQualifier($metadata, $type);
     }
     
+
+  /**
+   * Get Metadata object
+   * @param type $type
+   * @return array
+   */
+  function getAllMetaDataByQualifier($type,$level)
+    {
+    $lastRevision = $this->getRevision();
+    try {
+       $revisionNum = $lastRevision->getRevision();
+    } catch (Exception $e) {
+       $revisionNum=1;
+    }
+    if($revisionNum >0)
+        {
+        for($i = $revisionNum; $i > 0; $i--)
+            {
+            $searchReturn = '';
+            $revision = $this->getModel()->getRevision($this, $i);
+            if($revision)
+                {
+                $metadata = MidasLoader::loadModel('ItemRevision')->getMetadata($revision);
+                $searchReturn =  $this->_getMetaDataByQualifier($metadata, $type);
+
+                }
+            if($searchReturn)
+              {
+              $test = strpos($level,$searchReturn->getValue());
+              }
+            if($searchReturn && (strpos($level,$searchReturn->getValue()) !== false))
+                {
+                return array($searchReturn,$i);
+                }
+            }
+        }
+    return array(false,0);
+    }
   /**
    * Get Metadata object implementation
    * @param type $type

--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -250,7 +250,7 @@ function ajaxSearch(append,fullQuery,certLevel) {
           addAndFormatResult($('.SearchResults'), {'rating': value.rating, 'type': value.type,
             'id':value.revisionId, 'title': value.title, "logo": value.logo,
             'description': value.description, 'statistics': value.statistics,
-            'authors': value.authors, 'isCertified' : value.isCertified, 'certifiedLevel': value.certifiedLevel,'revisionID': value.revisionID})
+            'authors': value.authors, 'isCertified' : value.isCertified, 'certifiedLevel': value.certifiedLevel,'pastCertificationID': value.pastCertificationID})
           })
           var shown = $('.resourceLink').length;
           if(total > shown)
@@ -322,9 +322,9 @@ function addAndFormatResult(container, values) {
   else
     {
     var revisionText = ''
-    if(values.revisionID !== "")
+    if(values.pastCertificationID !== "")
       {
-      revisionText = "Revision " + values.revisionID + ": ";
+      revisionText = "Revision " + values.pastCertificationID + ": ";
       }
     newElement.find('.CertifiedLevel').html(revisionText + "(Level "+values.certifiedLevel+")");
     }

--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -164,7 +164,22 @@ function searchDatabase(append)
     fullQuery += "AND (name:("+query+") OR description:("+query+"))";
     }
 
+
+  if(selectIssue)
+    {
+    fullQuery+= " AND (";
+    fullQuery+= " text-journal.issue:"+selectIssue+" ";
+    fullQuery+= ")";
+    }
+  if(json.selectedCommunity != "")
+    {
+    fullQuery+= " AND (";
+    fullQuery+= " text-journal.community:"+json.selectedCommunity+" ";
+    fullQuery+= ")";
+    }
+  var allQuery = fullQuery;
   var categories = getSelectedCategories();
+  var certLevel =  [];
   if(categories.length != 0)
     {
     $.each(categories, function(idx, val){
@@ -174,6 +189,7 @@ function searchDatabase(append)
         if(value.indexOf("certified") != -1)
           {
           fullQuery+= "text-journal.certification_level:"+value.charAt(value.length - 1)+" ";
+          certLevel.push(value.charAt(value.length - 1));
           }
         else if(value.indexOf("submission_type") != -1)
           {
@@ -204,25 +220,23 @@ function searchDatabase(append)
     });
     }
 
-  if(selectIssue)
-    {
-    fullQuery+= " AND (";
-    fullQuery+= " text-journal.issue:"+selectIssue+" ";
-    fullQuery+= ")";
-    }
-  if(json.selectedCommunity != "")
-    {
-    fullQuery+= " AND (";
-    fullQuery+= " text-journal.community:"+json.selectedCommunity+" ";
-    fullQuery+= ")";
-    }
 
   $('img#searchLoadingImg').show();
+  ajaxSearch(append,fullQuery,certLevel);
+  if(certLevel != 0)
+   {
+   ajaxSearch(append, allQuery,certLevel);
+   }
+}
+
+
+function ajaxSearch(append,fullQuery,certLevel) {
+
   var shown = $('.resourceLink').length;
   if(!append) shown = 0;
   ajaxWebApi.ajax({
         method: 'midas.journal.search',
-        args: "offset="+shown+"&query="+fullQuery,
+        args: "offset="+shown+"&query="+fullQuery+"&level="+certLevel,
         log: true,
         success: function (retVal) {
           $('img#searchLoadingImg').hide();
@@ -236,12 +250,10 @@ function searchDatabase(append)
           addAndFormatResult($('.SearchResults'), {'rating': value.rating, 'type': value.type,
             'id':value.revisionId, 'title': value.title, "logo": value.logo,
             'description': value.description, 'statistics': value.statistics,
-            'authors': value.authors, 'isCertified' : value.isCertified, 'certifiedLevel': value.certifiedLevel})
+            'authors': value.authors, 'isCertified' : value.isCertified, 'certifiedLevel': value.certifiedLevel,'revisionID': value.revisionID})
           })
-
           var shown = $('.resourceLink').length;
-
-          if(total != shown)
+          if(total > shown)
             {
             $('#showMoreResults').show();
             $('#showMoreResults a').unbind('click').click(function(){
@@ -277,7 +289,7 @@ function searchDatabase(append)
         complete: function () {
         }
     });
-  }
+}
 
 /** Simple templating mechanism */
 function addAndFormatResult(container, values) {
@@ -309,7 +321,12 @@ function addAndFormatResult(container, values) {
     }
   else
     {
-    newElement.find('.CertifiedLevel').html("(Level "+values.certifiedLevel+")");
+    var revisionText = ''
+    if(values.revisionID !== "")
+      {
+      revisionText = "Revision " + values.revisionID + ": ";
+      }
+    newElement.find('.CertifiedLevel').html(revisionText + "(Level "+values.certifiedLevel+")");
     }
 
   newElement.find('.ResultDescription').dotdotdot();


### PR DESCRIPTION
Add another ajax search to the certification filter to check for submissions
that have previous revisions that have been certified.

It does this by adding a second database call which searches through each revision of a submission for a matching certification level.
