### PR TITLE
Encode description in email messages.

### DIFF
--- a/views/email/newsubmission.phtml
+++ b/views/email/newsubmission.phtml
@@ -17,7 +17,7 @@
                   <p style="text-align:justify;text-justify:inter-word;">A new submission has been added to OSEHRA Technical Journal.</p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo $this->name ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo $this->description ?></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description) ?></p>
                   <br>
                   <p style="text-align:justify;text-justify:inter-word;">Download and review this publication at:
                     <a style="color:#ee5624;font-family:Arial,Helvetica,sans-serif;font-weight:bold;font-size:10pt"

--- a/views/email/sendforapproval.phtml
+++ b/views/email/sendforapproval.phtml
@@ -17,7 +17,7 @@
                   <p style="text-align:justify;text-justify:inter-word;">A new submission needs your approval. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo $this->name ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",($this->description)) ?></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description) ?></p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>License:</b> <?php echo $this->license ?></p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Agreed to Contributed Software Attribution Policy:</b> <?php echo $this->attributionPolicy ?></p>
                   <br>

--- a/views/email/sendforapproval.phtml
+++ b/views/email/sendforapproval.phtml
@@ -17,7 +17,7 @@
                   <p style="text-align:justify;text-justify:inter-word;">A new submission needs your approval. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo $this->name ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo $this->description ?></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",($this->description)) ?></p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>License:</b> <?php echo $this->license ?></p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Agreed to Contributed Software Attribution Policy:</b> <?php echo $this->attributionPolicy ?></p>
                   <br>

--- a/views/email/updatedsubmission.phtml
+++ b/views/email/updatedsubmission.phtml
@@ -17,7 +17,7 @@
                   <p style="text-align:justify;text-justify:inter-word;">A submission has been updated in the OSEHRA Technical Journal.</p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo $this->name ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo $this->description ?></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description) ?></p>
                   <br>
                   <p style="text-align:justify;text-justify:inter-word;">Download and review this publication at:
                     <a style="color:#ee5624;font-family:Arial,Helvetica,sans-serif;font-weight:bold;font-size:10pt"


### PR DESCRIPTION
Certain versions of apostrophes were being passed to the email text
as a set of odd symbols.  Use ICONV with tranlit to convert the
description to 'ISO-8859-1' as the email is generated.

OSEHRA-ID: http://issues.osehra.org/view/OTJ-43
