### PR TITLE
Fix some whitespace and typos

### DIFF
--- a/controllers/SubmitController.php
+++ b/controllers/SubmitController.php
@@ -24,7 +24,7 @@ class Journal_SubmitController extends Journal_AppController
 
     }
 
-  /** The first step of the submission process is  to select an issue */
+  /** The first step of the submission process is to select an issue */
   function selectissueAction()
     {
     if(!$this->logged)
@@ -96,7 +96,7 @@ class Journal_SubmitController extends Journal_AppController
       $resourceDao->setRevision("New");
       $isNewSubmission = true;
       $folder = MidasLoader::loadModel("Folder")->load($issueId);
-      if(!$folder)throw new Zend_Exception("Unable to find issuse.");
+      if(!$folder)throw new Zend_Exception("Unable to find issue.");
       $this->view->json['showlicence'] = 1;
       }
 
@@ -153,7 +153,6 @@ class Journal_SubmitController extends Journal_AppController
             }
           }
         }
-
       MidasLoader::loadModel('Folder')->addItem($this->view->issueDao, $resourceDao, false);
       $resourceDao->enable();
 
@@ -325,7 +324,7 @@ class Journal_SubmitController extends Journal_AppController
     $community =  MidasLoader::loadModel("Folder")->getCommunity(MidasLoader::loadModel("Folder")->getRoot($issue));
     $memberGroup = $community->getMemberGroup();
 
-    // Check if public or private (If private, it means it requires approval
+    // Check if public or private (If private, it means it requires approval)
     $private = true;
     foreach($resourceDao->getItempolicygroup() as $policy)
       {
@@ -435,7 +434,7 @@ class Journal_SubmitController extends Journal_AppController
 
     $submitter = $resourceDao->getSubmitter();
 
-    // sent to theview
+    // sent to the view
     $this->view->isPrivate = $private;
     $this->view->isAdmin = $resourceDao->isAdmin($this->userSession->Dao);
     $this->view->isSubmitter = $submitter && $submitter->getKey() == $this->userSession->Dao->getKey();

--- a/controllers/ViewController.php
+++ b/controllers/ViewController.php
@@ -202,7 +202,7 @@ class Journal_ViewController extends Journal_AppController
     $community = MidasLoader::loadModel("Folder")->getCommunity(MidasLoader::loadModel("Folder")->getRoot( $issue));
     $memberGroup = $community->getMemberGroup();
 
-    // Check if public or private (If private, it means it requires approval
+    // Check if public or private (If private, it means it requires approval)
     $private = true;
     $isApproved = false;
     foreach($resourceDao->getItempolicygroup() as $policy)
@@ -265,7 +265,7 @@ class Journal_ViewController extends Journal_AppController
     $this->view->resource = $resourceDao;
     $this->view->issue =  $issue;
     $this->view->paper = $paper;
-    $this->view->revisions =  $itemDao->getRevisions();;
+    $this->view->revisions =  $itemDao->getRevisions();
     $this->view->community =  $community;
     $this->view->creationDate = MidasLoader::loadComponent("Date")->formatDate(strtotime($resourceDao->getDateCreation()));
     $this->view->termFrequency = file_get_contents("http://localhost:8983/solr/admin/luke?fl=text-journal.tags&wt=json&numTerms=200&reportDocCount=false");

--- a/views/submit/upload.phtml
+++ b/views/submit/upload.phtml
@@ -25,12 +25,16 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
 <link rel="stylesheet" href="<?php echo $this->webroot ?>/privateModules/journal/public/js/lib/jQuery-File-Upload-8.4.0/css/jquery.fileupload-ui.css">
 
 <div class="viewMain">
-  <h3>Manage files.</h3>
+  <h3>Manage files</h3>
 
-  <p>This article will be assigned the following handle: http://hdl.handle.net/<?php echo $this->resource->getHandle()?>. Note that the handle will be activated only when the article is accepted for publication.
+  <p>
+    This article will be assigned the following handle:
+    http://hdl.handle.net/<?php echo $this->resource->getHandle()?>. Note that
+    the handle will be activated only when the article is accepted for publication.
   </p>
   <p>
-    The purpose of this page is to upload the documents and datasets related to your article. You can also upload a Logo which will be shown on the article's page.
+    The purpose of this page is to upload the documents and datasets related to
+    your article. You can also upload a Logo which will be shown on the article's page.
   </p>
 
 
@@ -143,7 +147,7 @@ I have the right to distribute these files
       {
       echo "
       <input type='checkbox' checked='true' class='checkbox' id='sendNotificationEmail' value='0'>
-      <label style='display:inline;' for='sendNotificationEmail'> Send notification email</label>
+      <label style='display:inline;' for='sendNotificationEmail'>Send notification email</label>
       <br/>
       <br/>";
       }

--- a/views/view/index.phtml
+++ b/views/view/index.phtml
@@ -124,7 +124,7 @@ foreach ($cssArray as $module => $list)
       if(!empty($grant))
         {
         ?>
-        <li>Grand: <?php echo $grant ?></li>
+        <li>Grant: <?php echo $grant ?></li>
       <?php
         }
       $lastRevision = MidasLoader::loadModel('Item')->getLastRevision($this->resource);


### PR DESCRIPTION
- 'Grand' --> 'Grant' (on publication main page)
- Removed '.' from 'Manage Files.'
