### PR TITLE
Add direct links when filtering by certification level

### DIFF
--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -128,7 +128,7 @@ class Journal_ApiComponent extends AppComponent
 
         if($args['level'] !== '')
           {
-          list($level,$foundRevision) = $resourceDao->getAllCertificationLevel($args['level']);
+          list($level,$foundRevisionID,$foundRevisionKey) = $resourceDao->getAllCertificationLevel($args['level']);
           }
         else
           {
@@ -148,7 +148,8 @@ class Journal_ApiComponent extends AppComponent
             'rating' => (float)$rating['average'], 'type' => $item->getType(), 'logo' => $resourceDao->getLogo(),
             'id' => $item->getKey(), 'description' => htmlentities($item->getDescription(), ENT_COMPAT | ENT_HTML401, "UTF-8" ),
             'authors' => $authors, 'view' => $item->getView() ,'downloads' => $resourceDao->getDownload(), 'statistics' => $statistics,
-            'revisionId' => $resourceDao->getRevision()->getKey(), "isCertified" => $isCertified, 'pastCertificationID' => $foundRevision, "certifiedLevel" => $level);
+            'revisionId' => $resourceDao->getRevision()->getKey(), "isCertified" => $isCertified, 'pastCertificationRevisionNum' => $foundRevisionID, "certifiedLevel" => $level,
+            'pastCertificationRevisionKey' => $foundRevisionKey);
 
           $count++;
           }

--- a/models/dao/ResourceDao.php
+++ b/models/dao/ResourceDao.php
@@ -216,9 +216,9 @@ class Journal_ResourceDao extends ItemDao
    */
   function getAllCertificationLevel($level)
     {
-    list($metadata,$revisionID) = $this->getAllMetaDataByQualifier("certification_level",$level);
+    list($metadata,$foundRevisionID,$foundRevisionKey) = $this->getAllMetaDataByQualifier("certification_level",$level);
     if(!$metadata) return '';
-    return array($metadata->getValue(),$revisionID);
+    return array($metadata->getValue(),$foundRevisionID,$foundRevisionKey);
     }
 
    /* Set Certification level
@@ -718,15 +718,10 @@ class Journal_ResourceDao extends ItemDao
                 {
                 $metadata = MidasLoader::loadModel('ItemRevision')->getMetadata($revision);
                 $searchReturn =  $this->_getMetaDataByQualifier($metadata, $type);
-
                 }
-            if($searchReturn)
-              {
-              $test = strpos($level,$searchReturn->getValue());
-              }
             if($searchReturn && (strpos($level,$searchReturn->getValue()) !== false))
                 {
-                return array($searchReturn,$i);
+                return array($searchReturn,$i,$revision->getKey());
                 }
             }
         }

--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -323,7 +323,7 @@ function addAndFormatResult(container, values) {
     else
       {
       var revisionText = ''
-      if(values.pastCertificationID !== "")
+      if(values.pastCertificationRevisionNum !== "")
         {
         revisionText = "Revision " + values.pastCertificationRevisionNum + ": ";
         }

--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -245,7 +245,8 @@ function ajaxSearch(append,fullQuery,allQuery,certLevel) {
           addAndFormatResult($('.SearchResults'), {'rating': value.rating, 'type': value.type,
             'id':value.revisionId, 'title': value.title, "logo": value.logo,
             'description': value.description, 'statistics': value.statistics,
-            'authors': value.authors, 'isCertified' : value.isCertified, 'certifiedLevel': value.certifiedLevel,'pastCertificationID': value.pastCertificationID})
+            'authors': value.authors, 'isCertified' : value.isCertified, 'certifiedLevel': value.certifiedLevel,'pastCertificationRevisionNum': value.pastCertificationRevisionNum,
+            'pastCertificationRevisionKey': value.pastCertificationRevisionKey})
           })
           var shown = $('.resourceLink').length;
           if(total > shown)
@@ -290,6 +291,10 @@ function ajaxSearch(append,fullQuery,allQuery,certLevel) {
 function addAndFormatResult(container, values) {
   if (container.html().indexOf(values['title']) == -1) {
     var str = document.getElementById('SearchResultTemplate').innerHTML;
+      if(values.pastCertificationRevisionKey !== "")
+        {
+        values.id = values.pastCertificationRevisionKey;
+        }
     $.each(values, function(key,value)
      {
      str = str.replace("{"+key+"}", value);
@@ -320,7 +325,7 @@ function addAndFormatResult(container, values) {
       var revisionText = ''
       if(values.pastCertificationID !== "")
         {
-        revisionText = "Revision " + values.pastCertificationID + ": ";
+        revisionText = "Revision " + values.pastCertificationRevisionNum + ": ";
         }
       newElement.find('.CertifiedLevel').html(revisionText + "(Level "+values.certifiedLevel+")");
       }


### PR DESCRIPTION
Change the links of the main journal page when filtering by certification
level.  Instead of redirecting to the lastest revision, instead point to
the version that has the desired certification.

OSEHRA-Id: http://issues.osehra.org/browse/OTJ-44
