### PR TITLE
Add new field to search string

### DIFF
--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -167,7 +167,7 @@ function searchDatabase(append)
       query += vals[i];
       }
 
-    fullQuery += "AND (name:("+query+") OR description:("+query+"))";
+    fullQuery += "AND (name:("+query+") OR description:("+query+") OR ngram_search:("+query+"))";
     }
 
 


### PR DESCRIPTION
To allow for substring searches, Add a new field to search called
ngram_search which is a copy of the name and description fields.  This
field should use the EdgeNGram tokenizer instead of the whitespace one.

Add this ngram_search field to the Journal code which builds the query
from the search box.

The changes 
