### PR TITLE
Fix overlap in menu bar

### DIFF
--- a/layouts/osehra.phtml
+++ b/layouts/osehra.phtml
@@ -197,7 +197,7 @@ echo $this->doctype()
         
            </div>
         </div>
-          <div id="topbar"><ul id="Nav" class="nav"><li id='browseLink'><a href="<?php echo $this->webroot ?>/journal">Home</a></li>
+          <div id="topbar"><ul id="Nav" class="nav navbar-nav"><li id='browseLink'><a href="<?php echo $this->webroot ?>/journal">Home</a></li>
 
            <li>
              <a  href="<?php echo $this->webroot."/journal/view/journals"?>">Journal</a>
@@ -290,7 +290,7 @@ echo $this->doctype()
           </ul>
 
      
-    <div class="HeaderSearch">
+    <div class="HeaderSearch nav navbar-nav navbar-right">
 
           <input type="text" class="panelsBackground" id="live_search" value="<?php echo (isset($this->query))? $this->query:'Search...'; ?>" autocomplete="off" autocorrect="off" autocapitalize="off" />
           <input type="hidden" id="live_search_value" value="init"  />

--- a/public/css/index/index.index.css
+++ b/public/css/index/index.index.css
@@ -130,6 +130,7 @@ div.SearchResultEntry:hover{
 
 div#infoElement{
   height:90px;
+  min-width: 450px;
   overflow-x: hidden;
   overflow-y: hidden;
   -webkit-box-shadow: #AAA 0 0 3px;


### PR DESCRIPTION
Fix the overlapping of the search items and the other menu buttons which occurs when the window is reduced in size.
Adding the navbar-right ensures the search will stay in the upper right corner and will be pushed below when the overlap occurs.
