### PR TITLE
Fix statistics page links

### DIFF
--- a/controllers/StatisticsController.php
+++ b/controllers/StatisticsController.php
@@ -210,13 +210,16 @@ class Journal_StatisticsController extends Journal_AppController
     foreach($results as $res)
       {
       $item = MidasLoader::loadModel(('Item'))->load($res["item_id"]);
-      $resourceDao = MidasLoader::loadModel("Item")->initDao("Resource", $item->toArray(), "journal");
-      $pub = array();
-      $pub['id'] = $resourceDao->getKey();
-      $pub['title'] = $resourceDao->getName();
-      $pub['downloads'] = $res["num"];
+      if($item)
+        {
+        $resourceDao = MidasLoader::loadModel("Item")->initDao("Resource", $item->toArray(), "journal");
+        $pub = array();
+        $pub['id'] = $resourceDao->getKey();
+        $pub['title'] = $resourceDao->getName();
+        $pub['downloads'] = $res["num"];
 
-      $publications[$pub['title']] = $pub;
+        $publications[$pub['title']] = $pub;
+        }
       }
     foreach($publications as $key => $row)
     {

--- a/controllers/StatisticsController.php
+++ b/controllers/StatisticsController.php
@@ -150,6 +150,7 @@ class Journal_StatisticsController extends Journal_AppController
       $pub['date'] = $revision->getDate();
       $pub['views'] = $resourceDao->getView();;
       $pub['downloads'] = $resourceDao->getDownload();
+      $pub['handle'] = $resourceDao->getHandle();
 
       $usLocale = new Zend_Locale('en_US');
       $zDate = new Zend_Date($pub['date']);
@@ -217,6 +218,7 @@ class Journal_StatisticsController extends Journal_AppController
         $pub['id'] = $resourceDao->getKey();
         $pub['title'] = $resourceDao->getName();
         $pub['downloads'] = $res["num"];
+        $pub['handle'] = $resourceDao->getHandle();
 
         $publications[$pub['title']] = $pub;
         }

--- a/views/statistics/index.phtml
+++ b/views/statistics/index.phtml
@@ -66,7 +66,8 @@ PURPOSE.  See the above copyright notices for more information.
         {
         if($pub['licence'] == "N/A*") $showNaMessage = true;
         echo "<tr>";
-        echo "<td><a href=\"".$this->webroot."browse/publication/".$pub['id']."\" target='_blank'>".$pub['title']."</a></td>";
+        $handleUrl = "http://hdl.handle.net/".$pub['handle'];
+        echo "<td><a href=\"".$handleUrl."\" target='_blank'>".$pub['title']."</a></td>";
         echo "<td>".$pub['downloads']."</td>";
         echo "<tr>";
         }
@@ -95,7 +96,8 @@ PURPOSE.  See the above copyright notices for more information.
       {
       if($pub['licence'] == "N/A*") $showNaMessage = true;
       echo "<tr>";
-      echo "<td><a href=\"".$this->webroot."browse/publication/".$pub['id']."\" target='_blank'>".$pub['title']."</a></td>";
+      $handleUrl = "http://hdl.handle.net/".$pub['handle'];
+      echo "<td><a href=\"".$handleUrl."\" target='_blank'>".$pub['title']."</a></td>";
       echo "<td>".$pub['licence']."</td>";
       echo "<td>".$pub['attribution']."</td>";
       echo "<td>".substr($pub['date'], 0, 10)."</td>";


### PR DESCRIPTION
Change links in "Statistics" page to use handle links
Change the information gathered by the statistics page for the
submission links to include the handle URL in the return.

Fix the broken links from a direct link to the Midas page of the item
to use a generated handle link instead.

(also contains commit from https://github.com/midasplatform/journal/pull/42)
