### PR TITLE
Add CSS to adjust for search bar shifting

### DIFF
--- a/public/css/layout/main.css
+++ b/public/css/layout/main.css
@@ -655,6 +655,8 @@ div.Content {
   border-radius: 2px;
   padding: 5px;
   margin-top: 15px;
+  float: left;
+  width: 100%;
 }
 
 div.ContentWithLeftPanel{


### PR DESCRIPTION
Add the css to make the "Content" div of the page have a  float style
This will ensure that it will adjust when the browser window is made
small enough that the search bar drops to a second line.

This is most visible on a submission page of the current functionality.
