### PR TITLE
Fix email for new comment

### DIFF
--- a/views/email/newcomment.phtml
+++ b/views/email/newcomment.phtml
@@ -17,7 +17,7 @@
 
                   <p style="text-align:justify;text-justify:inter-word;">A new comment has been added to OSEHRA Technical Journal submission: <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->title) ?>.</p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Commented By:</b> <?php echo $this->name ?>. </p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Comments:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT", $this->comments ?)></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Comments:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT", $this->comments) ?></p>
                   <br/>
                   <p style="text-align:justify;text-justify:inter-word;">Review/reply this comment at:
                     <a style="color:#ee5624;font-family:Arial,Helvetica,sans-serif;font-weight:bold;font-size:10pt"


### PR DESCRIPTION
The phtml of the email for the new comment contains a mis-aligned parenthesis.
Move it to the correct location so that the email can be sent and the page
reloads correctly.
