### PR TITLE
Add email list for new comments

### DIFF
--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -46,7 +46,7 @@ class Journal_UserController extends Journal_AppController
     if(isset($_POST) && !empty($_POST))
       {
       MidasLoader::loadComponent("Notification", "journal")->setUserNotificationStatus($this->userSession->Dao, 
-              $_POST['NewSubmissionEmail'], $_POST['NewReviewsEmail']);
+              $_POST['NewSubmissionEmail'], $_POST['NewReviewsEmail'], $_POST['NewCommentEmail']);
       $this->disableView();
       echo JsonComponent::encode(array(1, "Changes saved."));
       }

--- a/database/upgrade/1.0.5.php
+++ b/database/upgrade/1.0.5.php
@@ -1,0 +1,24 @@
+<?php
+class Journal_Upgrade_1_0_5 extends MIDASUpgrade
+{
+  public function preUpgrade()
+    {
+
+    }
+
+  public function mysql()
+    {
+    $sql = "ALTER TABLE user ADD journalmodule_notification_comments tinyint(4) DEFAULT 1;";
+    $this->db->query($sql);   
+    }
+
+  public function pgsql()
+    {
+
+    }
+
+  public function postUpgrade()
+    {
+    }
+}
+?>

--- a/views/user/notification.phtml
+++ b/views/user/notification.phtml
@@ -43,6 +43,13 @@ echo '<script type="text/javascript" src="' . $this->webroot . '/privateModules/
           <input type="radio" name="NewReviewsEmail" value="0" <?php if($this->status[1] == 0) echo "checked='checked'"?>>
           No</td>
       </tr>
+      <tr>
+        <td height="17" valign="top">Receive email when there a new comment is posted:
+          <input type="radio" name="NewCommentEmail" value="1" <?php if($this->status[2] == 1) echo "checked='checked'"?>>
+          Yes
+          <input type="radio" name="NewCommentEmail" value="0" <?php if($this->status[2] == 0) echo "checked='checked'"?>>
+          No</td>
+      </tr>
             
       <tr>
         <td>&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
Add a Notification configuration choice to determine if the user
should receive an email when a comment is posted to any submission.  Keep the Administrators copied on all comments explicitly

Add the database upgrade script to add the new field and the new
default value for it.
