### PR TITLE
Fix the grammar of the 'comment notification' question

### DIFF
--- a/views/user/notification.phtml
+++ b/views/user/notification.phtml
@@ -44,7 +44,7 @@ echo '<script type="text/javascript" src="' . $this->webroot . '/privateModules/
           No</td>
       </tr>
       <tr>
-        <td height="17" valign="top">Receive email when there a new comment is posted:
+        <td height="17" valign="top">Receive email when a comment is posted for any submission:
           <input type="radio" name="NewCommentEmail" value="1" <?php if($this->status[2] == 1) echo "checked='checked'"?>>
           Yes
           <input type="radio" name="NewCommentEmail" value="0" <?php if($this->status[2] == 0) echo "checked='checked'"?>>


### PR DESCRIPTION
Change the wording of the comment notification selection in the
user profile to be a correct sentence.
