### PR TITLE
Swap submission date display

### DIFF
--- a/views/view/index.phtml
+++ b/views/view/index.phtml
@@ -233,14 +233,14 @@ foreach ($cssArray as $module => $list)
           }
           ?>
       </center>
-
       <div class="journal">
-        Published in <a href="<?php echo $this->webroot ?>/journal?community=<?php echo $this->community->getKey() ?>"
+      Submitted by <?php echo $this->resource->getRevision()->getUser()->getFullName() ?> on <?php echo date("m-d-Y", strtotime($this->resource->getRevision()->getDate())) ?>.
+      </div>
+      <div class="submittedby">
+        Originally published in <a href="<?php echo $this->webroot ?>/journal?community=<?php echo $this->community->getKey() ?>"
                         ><?php echo $this->community->getName(); ?></a> - <a
                         href="<?php echo $this->webroot ?>/journal?issue=<?php echo $this->issue->getKey() ?>"><?php echo $this->issue->getName() ?></a>.
-
       </div>
-      <div class="submittedby">Submitted by <?php echo $this->resource->getRevision()->getUser()->getFullName() ?> on <?php echo date("m-d-Y", strtotime($this->resource->getRevision()->getDate())) ?>.</div>
       <div class="abstract" style="text-align: justify;"><?php echo str_replace("<br>", "<br/>", nl2br($this->resource->getDescription())) ?></div>
 
       <?php


### PR DESCRIPTION
Switch the ordering of the date information for each submission.
Make the more recent information for each revision more prominent
and change the text of the submission issue to clarify that the
stated issue was for the original revision of the submission.

OSEHRA-Id: http://issues.osehra.org/browse/OTJ-74
