### PR TITLE
Remove handle value from survey link and filename

### DIFF
--- a/Notification.php
+++ b/Notification.php
@@ -49,7 +49,6 @@ class Journal_Notification extends ApiEnabled_Notification
   /** Run OTJ Survey Script on Submission */
   public function runSurvey($param)
     {
-    $handle = $param['handle'];
     $revisionId = $param['revision_id'];
     // Execute the OTJ survey on the submission
     // First get the bitstream paths needed
@@ -71,7 +70,7 @@ class Journal_Notification extends ApiEnabled_Notification
     $surveyCommand = escapeshellcmd($fullSurveyCmd);
     exec($surveyCommand);
     // Move file to the OTJ_Survey directory
-    $filelocation = BASE_PATH.'/privateModules/journal/OTJ_Survey'.$handle."_Results.txt";
+    $filelocation = BASE_PATH.'/privateModules/journal/OTJ_Survey/'.$revisionId."_Results.txt";
     $fullMvCmd = 'mv '.$surveyDir.'/SurveyResult.txt '.$filelocation;
     $mvCommand = escapeshellcmd($fullMvCmd);
     exec($mvCommand);

--- a/controllers/components/NotificationComponent.php
+++ b/controllers/components/NotificationComponent.php
@@ -94,8 +94,8 @@ class Journal_NotificationComponent extends AppComponent
     if (!empty($authList)) $authList = substr($authList, 0, -1);
     $approveLink = "/journal/submit?revisionId=" . $revisionId;
     $baseUrl = UtilityComponent::getServerURL().$fc->getBaseUrl();
-    $surveyLink = $baseUrl."/journal/survey?id=".$handle;
-    Zend_Registry::get('notifier')->notifyEvent('EVENT_JOURNAL_SUBMIT_APPROVAL', array('revision_id' => $revisionId, 'handle' => $handle));
+    $surveyLink = $baseUrl."/journal/survey?id=".$revisionId;
+    Zend_Registry::get('notifier')->notifyEvent('EVENT_JOURNAL_SUBMIT_APPROVAL', array('revision_id' => $revisionId));
 
     $this->_view->assign("name", $name);
     $this->_view->assign("author", $authList);


### PR DESCRIPTION
Change the code to use the revisionID value instead of the handle string
to eliminate the '/' value that is contained in the handle string
Leaving it there would lead to incorrect renaming of the output file or a
non-optimal link:

From a current submission:
   Result of Survey script: http://code.osehra.org/journal/journal/survey?id=10909/11230
