### PR TITLE
Fix Institution and Author URL search

### DIFF
--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -155,22 +155,46 @@ function searchDatabase(append)
 
     vals = vals.concat(query.split(" "));
 
+    fullQuery += "AND ("
+    // Account for the "Institution" and "Author" links from the submission page
+    // Replace the string with the correct SOLR field
+    // Assumes that only one of the values will be searched for at a time for now
+    var re = /(.*)\:(.*)/i;
+    var val = re.exec(query);
+    if (val != null)
+      {
+      if(val[1] == "institution")
+        {
+        query = query.replace(val[1], 'text-journal.insitution');
+        query = query.replace(val[2], "("+val[2]+")");
+        fullQuery += query +" OR ";
+        }
+      else if (val[1] == "authors")
+        {
+        query = query.replace(val[1], 'text-journal.authors');
+        query = query.replace(val[2], "("+val[2]+")");
+        fullQuery += query +" OR ";
+        }
+       }
+
     // Remove any empty values
     vals = vals.filter(function(val){
       return val !== "";
     });
 
     // Re-construct query
-    query = vals[0];
-    for (i = 1; i < vals.length; i++)
+    if( vals.length > 0 )
       {
-      query += " AND ";
-      query += vals[i];
+      query = vals[0];
+      for (i = 1; i < vals.length; i++)
+        {
+        query += " AND ";
+        query += vals[i];
+        }
+      fullQuery += "name:("+query+") OR description:("+query+") OR ngram_search:("+query+")";
       }
-
-    fullQuery += "AND (name:("+query+") OR description:("+query+") OR ngram_search:("+query+"))";
+    fullQuery += ")"
     }
-
 
   if(selectIssue)
     {

--- a/views/view/index.phtml
+++ b/views/view/index.phtml
@@ -211,10 +211,10 @@ foreach ($cssArray as $module => $list)
       </div>
       <div class="authors"><?php
       $authors = $this->resource->getAuthors();
-      foreach($authors as &$author) $author = '<a href="'.$this->webroot.'/journal/?q=text-journal.authors:'.$author[0].' '.$author[1].'">'.ucfirst($author[1]).' '.ucfirst($author[0][0]).'.</a>';
+      foreach($authors as &$author) $author = '<a href="'.$this->webroot.'/journal/?q=authors:'.$author[0].' '.$author[1].'">'.ucfirst($author[1]).' '.ucfirst($author[0][0]).'.</a>';
       echo join(', ', $authors);
       ?></div>
-      <div class="institution" > <a href="<?php echo $this->webroot ?>/journal/?q=text-journal.insitution:<?php echo ucfirst($this->resource->getInstitution()) ?>">
+      <div class="institution" > <a href="<?php echo $this->webroot ?>/journal/?q=institution:<?php echo ucfirst($this->resource->getInstitution()) ?>">
           <?php echo ucfirst($this->resource->getInstitution()) ?></a></div>
       <center>
         <?php


### PR DESCRIPTION
Fix the searching done when clicking on an author or institution name in
the main view of a submission.  Remove the SOLR field and replace it with
a text string.

Check for the string later and add a separate item in the query for the
additional parameter.
