### PR TITLE
Add HTML sanitization to OTJ Survey results

### DIFF
--- a/otjSurvey.py
+++ b/otjSurvey.py
@@ -15,8 +15,9 @@ OTJ_SURVEY_EXPRESSIONS = (("Do not [Re]*distribute",[]),
 )
 
 OTJ_FILE_EXCLUDES = ("dat","dll", "DAT","exe", "EXE", "mdf", "pdb", "class", "jpeg",
-    "jpg","png","gif","bmp","docx","pdf","vsd","doc", "xls", "xlsx", "ppt", "pptx")
-OTJ_UNZIP_EXCLUDES= ("EAP","dll")
+    "jpg","png","gif","bmp","docx","pdf","vsd","doc", "xls", "xlsx", "ppt", "pptx",
+    ".db","xml","XML")
+OTJ_UNZIP_EXCLUDES= ("EAP","dll","docx")
 OTJ_SURVEY_HISTORY = []
 global seven_zip
 

--- a/views/survey/index.phtml
+++ b/views/survey/index.phtml
@@ -36,7 +36,8 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
           foreach($result as $file)
             {
             $surveyResults = fopen($file,'r');
-            echo fread($surveyResults,filesize($file));
+            $data = mb_convert_encoding(fread($surveyResults,filesize($file)), 'UTF-8', 'ASCII');
+            echo htmlentities($data);
             fclose($surveyResults);
             };
           }


### PR DESCRIPTION
Add a call to the htmlentities function to escape any HTML that is
brought along with a found line in the OTJ Survey results.

Add in a few new OTJSurvey exclusions.

See http://code.osehra.org/journal/journal/survey?id=784 for an example of HTML being displayed on the page
