### PR TITLE
Add license information to main page of OTJ

### DIFF
--- a/controllers/components/ApiComponent.php
+++ b/controllers/components/ApiComponent.php
@@ -140,7 +140,7 @@ class Journal_ApiComponent extends AppComponent
             'id' => $item->getKey(), 'description' => htmlentities($item->getDescription(), ENT_COMPAT | ENT_HTML401, "UTF-8" ),
             'authors' => $authors, 'view' => $item->getView() ,'downloads' => $resourceDao->getDownload(), 'statistics' => $statistics,
             'revisionId' => $resourceDao->getRevision()->getKey(), "isCertified" => $isCertified, 'pastCertificationRevisionNum' => $foundRevisionID, "certifiedLevel" => $level,
-            'pastCertificationRevisionKey' => $foundRevisionKey);
+            'pastCertificationRevisionKey' => $foundRevisionKey, 'license' => $resourceDao->getSourceLicenseString());
           $count++;
           }
         }

--- a/public/css/index/index.index.css
+++ b/public/css/index/index.index.css
@@ -183,8 +183,14 @@ div.SearchResultEntry div.ResultAuthors{
   font-size: 12px;
   font-weight: bold;
 }
+div.SearchResultEntry div.ResultLicense{
+  float:right;
+  color: #333;
+  font-size: 13px;
+  font-weight: bold;
+}
 div.SearchResultEntry div.ResultDescription{
-  height: 61px;
+  height: 46px;
   margin-top:3px;
   line-height: 16px;
   font-size: 12px;

--- a/public/js/index/index.index.js
+++ b/public/js/index/index.index.js
@@ -285,7 +285,8 @@ function ajaxSearch(append,fullQuery,allQuery,certLevel) {
             'description': value.description, 'statistics': value.statistics,
             'authors': value.authors, 'isCertified' : value.isCertified, 'certifiedLevel': value.certifiedLevel,
             'pastCertificationRevisionNum': value.pastCertificationRevisionNum,
-            'pastCertificationRevisionKey': value.pastCertificationRevisionKey})
+            'pastCertificationRevisionKey': value.pastCertificationRevisionKey,
+            'license': value.license})
           })
 
           if(shown == (limit + lastIndex))

--- a/views/index/index.phtml
+++ b/views/index/index.phtml
@@ -147,17 +147,18 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
               <div class="ResultTop">
                 <a class="resourceLink" href="<?php echo $this->webroot ?>/journal/view/{id}"></a>
 
-                <span class="ResultTitle">{title}</span>          
+                <span class="ResultTitle">{title}</span>
               </div>
+                <div class="ResultLicense">
+                  Released under: {license}
+                </div>
               <div class="ResultAuthors">
                 {authors}
               </div>
               <div class="ResultDescription">
                 {description}
               </div>
-              <div class="ResultLicense">
-                Released under: {license}
-              </div>
+
             </td>
           </tr>
         </table>

--- a/views/index/index.phtml
+++ b/views/index/index.phtml
@@ -152,11 +152,12 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
               <div class="ResultAuthors">
                 {authors}
               </div>
-
               <div class="ResultDescription">
                 {description}
               </div>
-
+              <div class="ResultLicense">
+                Released under: {license}
+              </div>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
Add the license information to the template that is used to display
items on the main page of the OTJ.  Add the necessary CSS to emphasize
the license information.
