### PR TITLE
Add free-text option to "Other" license selection

### DIFF
--- a/controllers/SubmitController.php
+++ b/controllers/SubmitController.php
@@ -381,6 +381,10 @@ class Journal_SubmitController extends Journal_AppController
         if (isset($_POST['source-license']))
           {
           $resourceDao->setSourceLicense($_POST['source-license']);
+          if (($_POST['source-license'] == 3) && (isset($_POST['source-license-text'])))
+            {
+            $resourceDao->setSourceLicenseString($_POST['source-license-text']);
+            }
           }
         if (isset($_POST['attribution-policy']))
           {

--- a/models/dao/ResourceDao.php
+++ b/models/dao/ResourceDao.php
@@ -345,6 +345,22 @@ class Journal_ResourceDao extends ItemDao
     if(!$metadata) return '';
     return $metadata->getValue();
     }
+
+   /* Set source code license
+   * @param
+   */
+  function setSourceLicense($license)
+    {
+    $this->setMetaDataByQualifier("source_license", $license);
+    }
+
+
+
+  /**
+   * Get the text of the source license
+   * @return
+   *
+   */
   function getSourceLicenseString()
     {
     $metadata = $this->getMetaDataByQualifier("source_license");
@@ -358,7 +374,9 @@ class Journal_ResourceDao extends ItemDao
         return "Public Domain";
         break;
       case 3:
-        return "Other";
+        $license_string = $this->getMetaDataByQualifier("source_license_string");
+        if(!$license_string) return 'Other';
+        return htmlentities($license_string->getValue());
         break;
       case 4:
         return "GPL (Any Version)";
@@ -374,12 +392,13 @@ class Journal_ResourceDao extends ItemDao
       }
     }
 
-   /* Set source code license
+  /**
+   * Set the source_license_string
    * @param
    */
-  function setSourceLicense($license)
+  function setSourceLicenseString($license_string)
     {
-    $this->setMetaDataByQualifier("source_license", $license);
+    $this->setMetaDataByQualifier("source_license_string", htmlentities($license_string));
     }
 
   /** Get Agreed to Attribution Policy

--- a/public/js/submit/submit.upload.js
+++ b/public/js/submit/submit.upload.js
@@ -1,8 +1,7 @@
 
 $(document).ready(function(){
     $('#acceptRights').change(function(){
-      $('input[type=submit]').attr('disabled', !$(this).is(':checked') || 
-                                            ($('#acceptAttributionPolicy').is(":visible") && !$('#acceptAttributionPolicy').is(':checked')));
+      submitCheck();
     })
     
     $('#acceptRights').change();
@@ -10,8 +9,7 @@ $(document).ready(function(){
     $('#acceptAttributionPolicy').change(function(){
       var acceptAttributionPolicyIsSelected = $(this).is(":visible") && $(this).is(':checked');
       $('#hiddenAttributionPolicy').attr('value', acceptAttributionPolicyIsSelected ? 1 : 0);
-
-      $('input[type=submit]').attr('disabled', ($(this).is(":visible") && !$(this).is(':checked')) || !$('#acceptRights').is(':checked'));
+      submitCheck();
     })
     
     $('#acceptAttributionPolicy').change();
@@ -42,9 +40,7 @@ $(document).ready(function(){
         }
       var acceptAttributionPolicyIsSelected = $('#acceptAttributionPolicy').is(":visible") && $('#acceptAttributionPolicy').is(':checked');
       $('#hiddenAttributionPolicy').attr('value', acceptAttributionPolicyIsSelected ? 1 : 0);
-
-      $('input[type=submit]').attr('disabled', !$('#acceptRights').is(':checked') || 
-                                            ($('#acceptAttributionPolicy').is(":visible") && !$('#acceptAttributionPolicy').is(':checked')));
+      submitCheck();
     });
 
     $('#licenseChoice').change(function(){
@@ -74,12 +70,7 @@ $(document).ready(function(){
         }
       var acceptAttributionPolicyIsSelected = $('#acceptAttributionPolicy').is(":visible") && $('#acceptAttributionPolicy').is(':checked');
       $('#hiddenAttributionPolicy').attr('value', acceptAttributionPolicyIsSelected ? 1 : 0);
-
-
-
-      $('input[type=submit]').attr('disabled', !$('#acceptRights').is(':checked') || 
-                                            ($('#acceptAttributionPolicy').is(":visible") && !$('#acceptAttributionPolicy').is(':checked')) ||
-                                            ( $("#otherLicenseInput").is(":visible") && $("#otherLicenseInput").val() ));
+      submitCheck()
       });
    
     $('#licenseChoice').change();
@@ -96,6 +87,7 @@ $(document).ready(function(){
     $("#otherLicenseInput").change(function(){
     var otherLicenseIsFilled = $("#otherLicenseInput").is(":visible") && $("#otherLicenseInput").val();
     $('#hiddenSourceLicenseText').attr('value', otherLicenseIsFilled ? $("#otherLicenseInput").val() : "Other");
+    submitCheck();
     })
     // Set up change function to run when text area loses focus
     $("#otherLicenseInput").change()
@@ -157,7 +149,12 @@ $(document).ready(function(){
   KeepAlive();
 });
 
-
+function submitCheck()
+  {
+  $('input[type=submit]').attr('disabled',!$('#acceptRights').is(':checked') ||
+                                        ($('#acceptAttributionPolicy').is(":visible") && !$('#acceptAttributionPolicy').is(':checked')) ||
+                                        ($("#otherLicenseInput").is(":visible") && !$("#otherLicenseInput").val() ));
+  }
 function KeepAlive()
   {
   $.get(json.global.webroot+'/journal/help', function(data) { });

--- a/public/js/submit/submit.upload.js
+++ b/public/js/submit/submit.upload.js
@@ -30,7 +30,16 @@ $(document).ready(function(){
         $('#acceptAttributionPolicy').hide();
         $('#acceptAttributionPolicyLabel').hide();
         }
-
+      if(license==3 && $(this).is(':checked'))
+        {
+        $("#otherLicenseInput").show();
+        $("#otherLicenseInputLabel").show();
+        }
+      else
+        {
+        $("#otherLicenseInput").hide();
+        $("#otherLicenseInputLabel").hide();
+        }
       var acceptAttributionPolicyIsSelected = $('#acceptAttributionPolicy').is(":visible") && $('#acceptAttributionPolicy').is(':checked');
       $('#hiddenAttributionPolicy').attr('value', acceptAttributionPolicyIsSelected ? 1 : 0);
 
@@ -53,11 +62,24 @@ $(document).ready(function(){
         $('#acceptAttributionPolicyLabel').hide();
         }
 
+      if(license==3 && $('#acceptLicense').is(':checked'))
+        {
+        $("#otherLicenseInput").show();
+        $("#otherLicenseInputLabel").show();
+        }
+      else
+        {
+        $("#otherLicenseInput").hide();
+        $("#otherLicenseInputLabel").hide();
+        }
       var acceptAttributionPolicyIsSelected = $('#acceptAttributionPolicy').is(":visible") && $('#acceptAttributionPolicy').is(':checked');
       $('#hiddenAttributionPolicy').attr('value', acceptAttributionPolicyIsSelected ? 1 : 0);
 
+
+
       $('input[type=submit]').attr('disabled', !$('#acceptRights').is(':checked') || 
-                                            ($('#acceptAttributionPolicy').is(":visible") && !$('#acceptAttributionPolicy').is(':checked')));
+                                            ($('#acceptAttributionPolicy').is(":visible") && !$('#acceptAttributionPolicy').is(':checked')) ||
+                                            ( $("#otherLicenseInput").is(":visible") && $("#otherLicenseInput").val() ));
       });
    
     $('#licenseChoice').change();
@@ -69,6 +91,14 @@ $(document).ready(function(){
     })
 
     $('#sendNotificationEmail').change();
+    // Introduce free text license change
+
+    $("#otherLicenseInput").change(function(){
+    var otherLicenseIsFilled = $("#otherLicenseInput").is(":visible") && $("#otherLicenseInput").val();
+    $('#hiddenSourceLicenseText').attr('value', otherLicenseIsFilled ? $("#otherLicenseInput").val() : "Other");
+    })
+    // Set up change function to run when text area loses focus
+    $("#otherLicenseInput").change()
 
     $('#typeFile').change(function(){      
       if($(this).val() == 6)
@@ -132,4 +162,4 @@ function KeepAlive()
   {
   $.get(json.global.webroot+'/journal/help', function(data) { });
   setTimeout("KeepAlive()", 1000 * 60 * 5);
-  } 
+  }

--- a/views/submit/upload.phtml
+++ b/views/submit/upload.phtml
@@ -147,6 +147,8 @@ I have the right to distribute these files
       </option>
     </select>
      License (optional).</br></label>
+    <label style="display:inline;" for='otherLicenseInput' id='otherLicenseInputLabel'>Enter 'Other' License:</label>
+    <input type='text' id='otherLicenseInput' name="source-license-text">
     <input type="checkbox" <?php if ($this->resource->getAgreedAttributionPolicy()) echo "checked='true'";?>
            class="checkbox" id="acceptAttributionPolicy" value="1">
     <label style="display:inline;" for="acceptAttributionPolicy" id="acceptAttributionPolicyLabel"> 
@@ -187,6 +189,8 @@ I have the right to distribute these files
 
       <input name="source-license" type="hidden" id="hiddenSourceLicense"
              value='<?php if ($this->resource->getSourceLicense()) echo $this->resource->getSourceLicense(); else echo 0 ?>'/>
+      <input name="source-license-text" type="hidden" id="hiddenSourceLicenseText"
+             value='<?php if ($this->resource->getSourceLicenseString()) echo $this->resource->getSourceLicenseString(); else echo "" ?>'/>
       <input name="attribution-policy" type="hidden" id="hiddenAttributionPolicy"
              value='<?php if ($this->resource->getAgreedAttributionPolicy()) echo $this->resource->getAgreedAttributionPolicy(); else echo 0 ?>'/>
       <input name="send-email" type="hidden" id="hiddenSendNotificationEmail" value='0'/>

--- a/views/view/index.phtml
+++ b/views/view/index.phtml
@@ -156,7 +156,9 @@ foreach ($cssArray as $module => $list)
             echo "<li>License: Public Domain</li>";
             break;
           case 3:
-            echo "<li>License: Other</li>";
+            $license_string = $this->resource->getMetaDataByQualifier("source_license_string");
+            if(!$license_string) echo 'License: Other';
+            echo "<li>License: ".htmlentities($license_string->getValue())."</li>";
             break;
           case 4:
             echo "<li>License: <a href='https://opensource.org/licenses/gpl-license'>GPL (Any Version)</a></li>";


### PR DESCRIPTION
Add a text box which will allow the submitter to add the name
of a different license when the "Other" licensing option is
selected during submission.
