### PR TITLE
Make license attribution required for submission

### DIFF
--- a/public/js/submit/submit.upload.js
+++ b/public/js/submit/submit.upload.js
@@ -151,7 +151,7 @@ $(document).ready(function(){
 
 function submitCheck()
   {
-  $('input[type=submit]').attr('disabled',!$('#acceptRights').is(':checked') ||
+  $('input[type=submit]').attr('disabled',!$('#acceptRights').is(':checked') || !$('#acceptLicense').is(':checked') ||
                                         ($('#acceptAttributionPolicy').is(":visible") && !$('#acceptAttributionPolicy').is(':checked')) ||
                                         ($("#otherLicenseInput").is(":visible") && !$("#otherLicenseInput").val() ));
   }

--- a/views/submit/upload.phtml
+++ b/views/submit/upload.phtml
@@ -146,7 +146,7 @@ I have the right to distribute these files
               Other
       </option>
     </select>
-     License (optional).</br></label>
+     License.</br></label>
     <label style="display:inline;" for='otherLicenseInput' id='otherLicenseInputLabel'>Enter 'Other' License:</label>
     <input type='text' id='otherLicenseInput' name="source-license-text">
     <input type="checkbox" <?php if ($this->resource->getAgreedAttributionPolicy()) echo "checked='true'";?>


### PR DESCRIPTION
Add the logic to make the selection of a license for a submission
be required before it can be submitted for approval

Remove the optional string from the page.
