### PR TITLE
Fix description spacing and spelling in OTJ emails

### DIFF
--- a/views/email/newreview.phtml
+++ b/views/email/newreview.phtml
@@ -14,7 +14,7 @@
                 <div>
                   <br>
                   <p style="text-align:justify;text-justify:inter-word;">Hello,</p>
-                  <p style="text-align:justify;text-justify:inter-word;">A new review has beed added to OSEHRA Technical Journal submission: <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->title) ?>.</p>
+                  <p style="text-align:justify;text-justify:inter-word;">A new review has been added to OSEHRA Technical Journal submission: <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->title) ?>.</p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Reviewed By:</b> <?php echo $this->name ?>. </p>
                   <br>
                   <p style="text-align:justify;text-justify:inter-word;">You can see the detail of the review

--- a/views/email/newsubmission.phtml
+++ b/views/email/newsubmission.phtml
@@ -17,7 +17,7 @@
                   <p style="text-align:justify;text-justify:inter-word;">A new submission has been added to OSEHRA Technical Journal.</p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->name) ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description) ?></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo str_replace("<br>", "<br/>", nl2br(iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description))) ?></p>
                   <br>
                   <p style="text-align:justify;text-justify:inter-word;">Download and review this publication at:
                     <a style="color:#ee5624;font-family:Arial,Helvetica,sans-serif;font-weight:bold;font-size:10pt"

--- a/views/email/sendforapproval.phtml
+++ b/views/email/sendforapproval.phtml
@@ -17,7 +17,7 @@
                   <p style="text-align:justify;text-justify:inter-word;">A new submission needs your approval. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->name) ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description) ?></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo str_replace("<br>", "<br/>", nl2br(iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description))) ?></p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>License:</b> <?php echo $this->license ?></p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Agreed to Contributed Software Attribution Policy:</b> <?php echo $this->attributionPolicy ?></p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Result of Survey script:</b> <?php echo $this->surveyLink ?></p>

--- a/views/email/updatedsubmission.phtml
+++ b/views/email/updatedsubmission.phtml
@@ -18,7 +18,7 @@
                   <p style="text-align:justify;text-justify:inter-word;"><b>Title:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->name) ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Authors:</b> <?php echo $this->author ?>. </p>
                   <p style="text-align:justify;text-justify:inter-word;"><b>Revision Notes:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->revision_notes)?></p>
-                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description) ?></p>
+                  <p style="text-align:justify;text-justify:inter-word;"><b>Abstract:</b> <?php echo str_replace("<br>", "<br/>", nl2br(iconv("UTF-8", "ISO-8859-1//TRANSLIT",$this->description))) ?></p>
                   <br>
                   <p style="text-align:justify;text-justify:inter-word;">Download and review this publication at:
                     <a style="color:#ee5624;font-family:Arial,Helvetica,sans-serif;font-weight:bold;font-size:10pt"


### PR DESCRIPTION
Fix the "Abstract" sections to have the same spacing as shown on
each Submission page and as was entered during submission.

Fix the spelling of "been" in the "New Review" email
