### PR TITLE
Add Disclaimer to download page of OTJ

### DIFF
--- a/controllers/ConfigController.php
+++ b/controllers/ConfigController.php
@@ -28,6 +28,7 @@ class Journal_ConfigController extends Journal_AppController
     $this->view->adminEmail = MidasLoader::loadModel("Setting")->getValueByName('adminEmail', "journal");
     $this->view->baseHandle = MidasLoader::loadModel("Setting")->getValueByName('baseHandle', "journal");
     $this->view->oldWebsiteUrl = MidasLoader::loadModel("Setting")->getValueByName('oldWebsiteUrl', "journal");
+    $this->view->licenseDisclaimer = MidasLoader::loadModel("Setting")->getValueByName('licenseDisclaimer', "journal");
     $this->view->json['isConfigSaved'] = 0;
 
     if($this->_request->isPost() && is_numeric($_POST['defaultJournal']))
@@ -38,11 +39,13 @@ class Journal_ConfigController extends Journal_AppController
       $this->view->baseHandle = $_POST['baseHandle'];
       $this->view->adminEmail = $_POST['adminEmail'];
       $this->view->oldWebsiteUrl = $_POST['oldWebsiteUrl'];
+      $this->view->licenseDisclaimer = $_POST['licenseDisclaimer'];
       MidasLoader::loadModel("Setting")->setConfig('adminEmail', $this->view->adminEmail, "journal");
       MidasLoader::loadModel("Setting")->setConfig('defaultJournal', $this->view->defaultJournal, "journal");
       MidasLoader::loadModel("Setting")->setConfig('defaultLayout', $this->view->defaultLayout, "journal");
       MidasLoader::loadModel("Setting")->setConfig('baseHandle', $this->view->baseHandle, "journal");
       MidasLoader::loadModel("Setting")->setConfig('oldWebsiteUrl', $this->view->oldWebsiteUrl, "journal");
+      MidasLoader::loadModel("Setting")->setConfig('licenseDisclaimer', $this->view->licenseDisclaimer, "journal");
       if(is_numeric($this->view->baseHandle))
         {
         // This is a hack allowing us to use the Zend dispatch mechanisum to resolve the handles

--- a/public/js/view/view.download.js
+++ b/public/js/view/view.download.js
@@ -1,19 +1,38 @@
 // When page ready
 $(document).ready(function(){
 
-  if($('#disclaimerWrapper').length != 0)
+  if($('#disclaimerWrapperLicense').length != 0)
   {
     $.fancybox.open([
     {
-      href : '#disclaimerWrapper',
+      href : '#disclaimerWrapperLicense',
       closeBtn:false,
       helpers: {
         overlay: {closeClick: false}
       },
       keys : {
         close  : null
+      },
+      afterClose: function()
+        {
+        if($('#disclaimerWrapper').length != 0)
+        {
+          $.fancybox.open([
+          {
+            href : '#disclaimerWrapper',
+            closeBtn:false,
+            helpers: {
+              overlay: {closeClick: false}
+            },
+            keys : {
+              close  : null
+            }
+          }]);
+        }
       }
     }]);
   }
+
+
 });
 

--- a/views/config/index.phtml
+++ b/views/config/index.phtml
@@ -48,6 +48,10 @@ $this->headScript()->appendFile($this->webroot."/privateModules/journal/public/j
               <label for='test'>Old Website URL</label>
               <input type='text' name='oldWebsiteUrl' value='".$this->oldWebsiteUrl."'/>
             </div>
+            <div>
+              <label for='test'>Index of licensing disclaimer</label>
+              <input type='number' name='licenseDisclaimer' value='".$this->licenseDisclaimer."'/>
+            </div>
           <div>
             <input type='submit' value='Save Configuration'/>
           </div>

--- a/views/view/download.phtml
+++ b/views/view/download.phtml
@@ -52,6 +52,23 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
 </div>
 
 <?php
+  $disclaimerIndex = MidasLoader::loadModel("Setting")->getValueByName('licenseDisclaimer', "journal");
+  $disclaimer = MidasLoader::loadModel("Disclaimer", "journal")->load($disclaimerIndex);
+  if($disclaimer)
+    {
+    echo '<div id="disclaimerWrapperLicense" style="display:none;width:700px;"><h4>Disclaimer</h4>';
+    echo "<pre style:'white-space:pre-wrap'>".$disclaimer->getDescription()."</pre>";
+    echo "<br>
+      <table style='width:140px;margin:auto;'>
+        <tbody><tr>
+           <td> <a href='#' onclick='$.fancybox.close();'>Acknowledged</a></td>
+              <td>|</td>
+               <td><div align='center'><a href='".$this->webroot."/journal/view/?revisionId=".$this->resource->getRevision()->getKey()."'>Back</a></div></td>
+          </tr>
+        </tbody></table>";
+    echo "</div>";
+    }
+
 if($this->resource->getDisclaimer() != -1)
   {
   $disclaimer = MidasLoader::loadModel("Disclaimer", "journal")->load($this->resource->getDisclaimer());


### PR DESCRIPTION
Add a disclaimer to the download page for each submission.  The License
disclaimer must be generated and the disclaimer_id of the journal_disclaimer
table of the SQL instance must be set in the config page of the Journal module

NOTE: Not setting the disclaimer_id will prevent all disclaimers from being shown