### PR TITLE
Fix word breaks in disclaimer window

### DIFF
--- a/views/view/download.phtml
+++ b/views/view/download.phtml
@@ -57,7 +57,7 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
   if($disclaimer)
     {
     echo '<div id="disclaimerWrapperLicense" style="display:none;width:700px;"><h4>Disclaimer</h4>';
-    echo "<pre style:'white-space:pre-wrap'>".$disclaimer->getDescription()."</pre>";
+    echo "<pre style='word-break:unset'>".$disclaimer->getDescription()."</pre>";
     echo "<br>
       <table style='width:140px;margin:auto;'>
         <tbody><tr>
@@ -75,7 +75,7 @@ if($this->resource->getDisclaimer() != -1)
   if($disclaimer)
     {
     echo '<div id="disclaimerWrapper" style="display:none;width:700px;"><h4>Disclaimer</h4>';
-    echo "<pre>".$disclaimer->getDescription().'</pre>';
+    echo "<pre style='word-break:unset'>".$disclaimer->getDescription().'</pre>';
     echo "<br>
       <table style='width:140px;margin:auto;'>
         <tbody><tr>


### PR DESCRIPTION
Fix the 'word-break' style in the two disclaimer windows so that the
words are not broken up in the middle of the string.