### PR TITLE
Add style to last modal window

### DIFF
--- a/views/submit/index.phtml
+++ b/views/submit/index.phtml
@@ -274,7 +274,7 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
   <div align="center"><font size="+1"><strong>License</strong></font></div>
   <br>
 
-  <pre>You are licensing your work to OSEHRA Inc. under the 
+  <pre style='word-break:unset'>You are licensing your work to OSEHRA Inc. under the 
 Creative Commons Attribution License Version 3.0.
 
 You agree to the following:


### PR DESCRIPTION
Add the un-setting of the "word-break" style to the last modal window
that is used in the OTJ, the Creative Commons disclaimer shown before
the start of a submission.