### PR TITLE
Add Google RECAPTCHA to the OTJ Download

### DIFF
--- a/controllers/ConfigController.php
+++ b/controllers/ConfigController.php
@@ -29,6 +29,7 @@ class Journal_ConfigController extends Journal_AppController
     $this->view->baseHandle = MidasLoader::loadModel("Setting")->getValueByName('baseHandle', "journal");
     $this->view->oldWebsiteUrl = MidasLoader::loadModel("Setting")->getValueByName('oldWebsiteUrl', "journal");
     $this->view->licenseDisclaimer = MidasLoader::loadModel("Setting")->getValueByName('licenseDisclaimer', "journal");
+    $this->view->captchaSecret = MidasLoader::loadModel("Setting")->getValueByName('captchaSecret', "journal");
     $this->view->json['isConfigSaved'] = 0;
 
     if($this->_request->isPost() && is_numeric($_POST['defaultJournal']))
@@ -40,12 +41,14 @@ class Journal_ConfigController extends Journal_AppController
       $this->view->adminEmail = $_POST['adminEmail'];
       $this->view->oldWebsiteUrl = $_POST['oldWebsiteUrl'];
       $this->view->licenseDisclaimer = $_POST['licenseDisclaimer'];
+      $this->view->captchaSecret = $_POST['captchaSecret'];
       MidasLoader::loadModel("Setting")->setConfig('adminEmail', $this->view->adminEmail, "journal");
       MidasLoader::loadModel("Setting")->setConfig('defaultJournal', $this->view->defaultJournal, "journal");
       MidasLoader::loadModel("Setting")->setConfig('defaultLayout', $this->view->defaultLayout, "journal");
       MidasLoader::loadModel("Setting")->setConfig('baseHandle', $this->view->baseHandle, "journal");
       MidasLoader::loadModel("Setting")->setConfig('oldWebsiteUrl', $this->view->oldWebsiteUrl, "journal");
       MidasLoader::loadModel("Setting")->setConfig('licenseDisclaimer', $this->view->licenseDisclaimer, "journal");
+      MidasLoader::loadModel("Setting")->setConfig('captchaSecret', $this->view->captchaSecret, "journal");
       if(is_numeric($this->view->baseHandle))
         {
         // This is a hack allowing us to use the Zend dispatch mechanisum to resolve the handles

--- a/layouts/osehra.phtml
+++ b/layouts/osehra.phtml
@@ -67,6 +67,7 @@ echo $this->doctype()
 
     <?php echo $this->headLink();  // import the css ?>
     <?php echo $this->headStyle(); // import the css ?>
+    <script src='https://www.google.com/recaptcha/api.js'></script>
 </head>
 
 <body>

--- a/public/js/view/view.download.js
+++ b/public/js/view/view.download.js
@@ -1,6 +1,5 @@
 // When page ready
 $(document).ready(function(){
-
   if($('#disclaimerWrapperLicense').length != 0)
   {
     $.fancybox.open([

--- a/views/config/index.phtml
+++ b/views/config/index.phtml
@@ -52,6 +52,10 @@ $this->headScript()->appendFile($this->webroot."/privateModules/journal/public/j
               <label for='test'>Index of licensing disclaimer</label>
               <input type='number' name='licenseDisclaimer' value='".$this->licenseDisclaimer."'/>
             </div>
+            <div>
+              <label for='test'>Secret value for RECAPTCHA</label>
+              <input type='text' name='captchaSecret' value='".$this->captchaSecret."'/>
+            </div>
           <div>
             <input type='submit' value='Save Configuration'/>
           </div>

--- a/views/view/download.phtml
+++ b/views/view/download.phtml
@@ -28,33 +28,68 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
   <a href="<?php echo $this->webroot?>/journal/view/?revisionId=<?php echo $this->resource->getRevision()->getKey()?>">Back to article</a>
   <br/>
   <br/>
-  <ul>
-    <?php
-    $size = 0;
-    $bitstreams = $this->resource->getRevision()->getBitstreams();
-    foreach ($bitstreams as $bitstream)
-      {
-      $size += $bitstream->getSizebytes();
+
+  <?php
+     // Check for the presence of a completed recaptcha in
+     //  the form of a g-recaptcha-response parameter
+     // if none, show the recaptcha
+    if(!$_POST['g-recaptcha-response']) {
+        echo '  <form id="captchaform" method="POST" action="" name="input">
+                   <div class="g-recaptcha" data-sitekey="6LdgUw4UAAAAAAFQWVY8dLlwvnGaiEu7YCDIw51s"></div>
+                   <input id="verifyHuman" type="submit" value="Verify"></submit>
+                </form>';
+    }
+    // If it does exist
+    else {
+      // Query the google server for verification
+      $url = "https://www.google.com/recaptcha/api/siteverify";
+      $url = $url."?secret=".MidasLoader::loadModel("Setting")->getValueByName('captchaSecret', "journal");;
+      $url = $url."&response=".$_POST['g-recaptcha-response'];
+      // Use cURL to query Google for validation.
+      $curl = curl_init();
+      curl_setopt($curl, CURLOPT_URL, $url);
+      curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
+      curl_setopt($curl, CURLOPT_TIMEOUT, 15);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, TRUE);
+      curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, TRUE);
+      $curlData = curl_exec($curl);
+      curl_close($curl);
+      $res = json_decode($curlData, TRUE);
+
+      if($res['success'] == TRUE) {
+        // TRUE means that the query was verified and we have a user, show them the links
+        $size = 0;
+        $bitstreams = $this->resource->getRevision()->getBitstreams();
+        foreach ($bitstreams as $bitstream)
+          {
+          $size += $bitstream->getSizebytes();
+          }
+        echo '<ul style="display">
+                <li><a href='.$this->webroot.'/download?items='.$this->resource->getKey().','.$this->resource->getRevision()->getRevision().'>Download All</a>
+                ('.MidasLoader::loadComponent("Utility")->formatSize($size).')</li>';
+        if($this->paper)
+          {
+          echo '<li><a href='.$this->webroot.'/download?bitstream='.$this->paper->getKey() /'">Download Paper</a>
+        </li>';
+          }
+        echo '</ul>';
       }
-    ?>
-    <li><a href="<?php echo $this->webroot ?>/download?items=<?php echo $this->resource->getKey() ?>, <?php echo $this->resource->getRevision()->getRevision() ?>">Download All</a>
-      (<?php echo MidasLoader::loadComponent("Utility")->formatSize($size); ?>)</li>
-    <?php
-    if($this->paper)
-      {
-      ?>
-    <li><a href="<?php echo $this->webroot ?>/download?bitstream=<?php echo $this->paper->getKey() ?>">Download Paper</a>
-    </li>
-    <?php
+      else {
+          // Something didn't work right, try again
+          echo "The RECAPTCHA was unable to be verified.  Please try again:";
+          echo '  <form id="captchaform" method="POST" action="" name="input">
+                   <div class="g-recaptcha" data-sitekey="6LdgUw4UAAAAAAFQWVY8dLlwvnGaiEu7YCDIw51s"></div>
+                   <input id="verifyHuman" type="submit" value="Verify"></submit>
+                </form>';
       }
-      ?>
-  </ul>
+};
+ ?>
 </div>
 
 <?php
   $disclaimerIndex = MidasLoader::loadModel("Setting")->getValueByName('licenseDisclaimer', "journal");
   $disclaimer = MidasLoader::loadModel("Disclaimer", "journal")->load($disclaimerIndex);
-  if($disclaimer)
+  if($disclaimer && $_POST['g-recaptcha-response'] )
     {
     echo '<div id="disclaimerWrapperLicense" style="display:none;width:700px;"><h4>Disclaimer</h4>';
     echo "<pre style='word-break:unset'>".$disclaimer->getDescription()."</pre>";
@@ -69,7 +104,7 @@ $this->headScript()->appendFile($this->webroot . '/privateModules/journal/public
     echo "</div>";
     }
 
-if($this->resource->getDisclaimer() != -1)
+if(($this->resource->getDisclaimer() != -1) && $_POST['g-recaptcha-response'])
   {
   $disclaimer = MidasLoader::loadModel("Disclaimer", "journal")->load($this->resource->getDisclaimer());
   if($disclaimer)


### PR DESCRIPTION
Add the RECAPTCHA framework to the download page to eliminate
bot downloads of the software.

Add configuration for the administrators to add the RECAPTCHA
secret key on the configuration page for the Journal module

For more information or to acquire a secret key for a site, see
 https://www.google.com/recaptcha/intro/index.html