### PR TITLE
Remove "Updated Submission" emails from private entries

### DIFF
--- a/controllers/components/NotificationComponent.php
+++ b/controllers/components/NotificationComponent.php
@@ -182,6 +182,15 @@ class Journal_NotificationComponent extends AppComponent
   public function updatedArticle($resourceDao)
     {
     $this->getLogger()->info("Article is Updated");
+    $isPrivate = true;
+    foreach($resourceDao->getItempolicygroup() as $policy)
+      {
+      if($policy->getGroupId() == MIDAS_GROUP_ANONYMOUS_KEY)
+        {
+        $isPrivate = false;
+        }
+      }
+    // end determining section
     // @TODO Check user settings, but I do not think it has been implemented yet
     $fc = Zend_Controller_Front::getInstance();
     $baseUrl = UtilityComponent::getServerURL().$fc->getBaseUrl();
@@ -218,7 +227,9 @@ class Journal_NotificationComponent extends AppComponent
     $this->getLogger()->debug("Body Text is " . $bodyText);
     $subject = 'Updated Submission: ' . $name;
     $to = '';
-    $subList = $this->_getNewSubmissionSubscribeList();
+    if (!$isPrivate) {
+        $subList = $this->_getNewSubmissionSubscribeList();
+    }
     $editList = $this->_getSubmissionEditorEmails($resourceDao);
     $adminList = $this->_getSubmissionAdminEmails($resourceDao);
     $emailLstArray = array($subList, $editList, $adminList);


### PR DESCRIPTION
Add a parameter to check for the status of the submission prior to
sending out the "Updated Submission" email.  If the submission is
private, only send the email to the admins and the submitter.

If public, add the subscriber list to the email header.