### PR TITLE
Unhide OTJ Reviews when in "Complete" phase

### DIFF
--- a/views/index/index.phtml
+++ b/views/index/index.phtml
@@ -36,7 +36,7 @@ else
         {
         $hasSubmitterAReview = true;
         }
-      if($r->getType() != $this->reviewPhase) echo "<div class='hiddenReview'>";
+      if($r->getType() != $this->reviewPhase && ($phase!="Complete")) echo "<div class='hiddenReview'>";
       showReviews($r, $this->webroot);
       if($r->getType() != $this->reviewPhase) echo "</div>";
       }
@@ -46,7 +46,7 @@ else
         {
         $hasSubmitterAReview = true;
         }
-      if($r->getType() != $this->reviewPhase) echo "<div class='hiddenReview'>";
+      if($r->getType() != $this->reviewPhase && ( $phase!="Complete")) echo "<div class='hiddenReview'>";
       showReviews($r, $this->webroot);
       if($r->getType() != $this->reviewPhase) echo "</div>";
       }


### PR DESCRIPTION
Add the checks to ensure that the "hiddenreview" class is not
applied to the review diff when the phase of the review has been
moved to "Complete"

OSEHRA-Id: http://issues.osehra.org/browse/OTJ-78