### PR TITLE
Remove parsing of "Public_Report" directory

### DIFF
--- a/otjSurvey.py
+++ b/otjSurvey.py
@@ -53,8 +53,11 @@ def parseSubmission(inputPath,tmpDir):
           print "Processing file: %s" % filepath
           if (zipfile.is_zipfile(filepath)) or filepath.endswith("7z"):
             searchArchive(filepath, unzipPath, tmpDir)
-          elif os.path.isdir(filepath):
-            parseSubmission(filepath,tmpDir)
+          elif (os.path.isdir(filepath)):
+            if (not ("Public_Report" in filepath)):
+              parseSubmission(filepath,tmpDir)
+            else:
+              continue
           else:
             if not (filepath.endswith(OTJ_FILE_EXCLUDES)):
               outline= filepath


### PR DESCRIPTION
Add a check which prevents the parsing of the files within the
"Public_Report" directory.  This report is a series of HTML files
that talk about the code which was redacted from a CIF submission.

The licensing and copyright information in these report files makes
it difficult to find the messages from the source of the submission.

For example: http://code.osehra.org/journal/journal/survey?id=885