### PR TITLE
Add cookies to maintain searches across navigating

### DIFF
--- a/layouts/osehra.phtml
+++ b/layouts/osehra.phtml
@@ -197,7 +197,7 @@ echo $this->doctype()
         
            </div>
         </div>
-          <div id="topbar"><ul id="Nav" class="nav navbar-nav"><li id='browseLink'><a href="<?php echo $this->webroot ?>/journal">Home</a></li>
+          <div id="topbar"><ul id="Nav" class="nav navbar-nav"><li id='browseLink'><a>Home</a></li>
 
            <li>
              <a  href="<?php echo $this->webroot."/journal/view/journals"?>">Journal</a>
@@ -378,7 +378,23 @@ echo $this->doctype()
       var rawJson="<?php echo addslashes(trim($this->json))?>";
     </script>
 
-    
+    <script type="text/javascript">
+      $(document).ready(function(){
+        $("#browseLink").click(function ( event) {
+          event.preventDefault()
+          $('#infoElement').hide();
+          $('#live_search').val("");
+          document.cookie = "pastSearch=; expires= Thu, 01 Jan 1970 00:00:01 GMT; path="+$(".webroot").attr("value");
+          document.cookie = "searchParams=; expires= Thu, 01 Jan 1970 00:00:01 GMT; path="+$(".webroot").attr("value");
+          $("#treeWrapper div.categoryTree").each(function(i, n){
+             $(this).dynatree("getRoot").visit(function(node) {
+               node.select(false);
+             })
+          })
+          location.href = $(".webroot").attr("value")+"/journal"
+        })
+      });
+    </script>
     <script type="text/javascript">
     var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
     document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));


### PR DESCRIPTION
Add a cookie called "pastSearch" which will keep a record of the
item ids that were displayed most recently.  This will allow
a user to select an object and go back to the the same search
results as prior to the selection.  Clicking the "clear" button of
the search bar or clicking on the "Home" navigations
will remove the cookie.

Add a second cookie for the search parameters that was used which
will allow the navigation page to display which paramters were used
when navigating back to the page.

Each cookie will last for 30 minutes or until cleared.