### PR TITLE
Add cookie for Google OAuth redirect

### DIFF
--- a/public/js/layout/layout.js
+++ b/public/js/layout/layout.js
@@ -239,5 +239,7 @@ $(document).ready(function () {
           midas.loadAjaxDynamicBar('register', '/user/register');
       });
       }
-
+    var mydate = new Date();
+    mydate.setMinutes(mydate.getMinutes()+30);
+    document.cookie = 'redirectURL='+ window.location.href +'; expires= '+ mydate.toUTCString()+ '; path='+$(".webroot").attr("value");
 });


### PR DESCRIPTION
Add a cookie that keeps track of the current page that was loaded by
the journal which will allow the Google sign-on to take you back to
that page after completion.