### PR TITLE
Switch links to HTTPS

### DIFF
--- a/layouts/osehra.phtml
+++ b/layouts/osehra.phtml
@@ -106,13 +106,13 @@ echo $this->doctype()
           <div id="wrapper"> 
             <div id="header">
               <!--<h2>Resources</h2> -->
-              <a class="logo" href="http://osehra.org"><img src="http://www.osehra.org/profiles/drupal_commons/themes/commons_osehra_earth/images/logo.png" border="0" height="35" width="150"/></a>
+              <a class="logo" href="https://osehra.org"><img src="http://www.osehra.org/profiles/drupal_commons/themes/commons_osehra_earth/images/logo.png" border="0" height="35" width="150"/></a>
               <ul id="nav_primary">
-                <li><a href="http://www.osehra.org/groups" title="Open Source Workgroup">Open Source Workgroup</a></li>
-                <li><a href="http://issues.osehra.org" title="Fill bug reports, improvements and feature requests here">Issue Tracker</a></li>
-                <li><a href="http://wiki.osehra.org" title="The place to collaboratively author project documents, and to find documentation on the Open Source Project">Open Source Project Wiki</a></li>
-                <li><a href="http://code.osehra.org/journal/" title="OSEHRA Technical Journal">OSEHRA Technical Journal</a></li>
-                <li><a href="http://www.osehra.org/content/joining-osehra" title="OSEHRA is community driven - please join in!">Join OSEHRA</a></li>
+                <li><a href="https://www.osehra.org/groups" title="Open Source Workgroup">Open Source Workgroup</a></li>
+                <li><a href="https://issues.osehra.org" title="Fill bug reports, improvements and feature requests here">Issue Tracker</a></li>
+                <li><a href="https://wiki.osehra.org" title="The place to collaboratively author project documents, and to find documentation on the Open Source Project">Open Source Project Wiki</a></li>
+                <li><a href="https://code.osehra.org/journal/" title="OSEHRA Technical Journal">OSEHRA Technical Journal</a></li>
+                <li><a href="https://www.osehra.org/content/joining-osehra" title="OSEHRA is community driven - please join in!">Join OSEHRA</a></li>
               </ul>
             </div>
           </div>   
@@ -154,7 +154,7 @@ echo $this->doctype()
           <div id="menu">
         <div id="topmenu">
           <a style='border:none;' href="<?php echo $this->webroot?>">
-          <img style='border:none;' src="http://osehra.org/profiles/drupal_commons/themes/commons_osehra_earth/images/logo.png" alt="logo" height="50"/>
+          <img style='border:none;' src="https://osehra.org/profiles/drupal_commons/themes/commons_osehra_earth/images/logo.png" alt="logo" height="50"/>
           </a>
         </div>
         <div id="title">
@@ -328,7 +328,7 @@ echo $this->doctype()
            <br/>
            </div>
            <div class="copyright">
-             <a href="http://osehra.org"><img src="<?php echo $this->webroot ?>/privateModules/journal/public/images/osehra/big-logo.jpg" alt="Kitware Logo"/></a><br/>
+             <a href="https://osehra.org"><img src="<?php echo $this->webroot ?>/privateModules/journal/public/images/osehra/big-logo.jpg" alt="Kitware Logo"/></a><br/>
              <br/>
            
            </div>


### PR DESCRIPTION
In order to facilitate a change to HTTPS only, switch the links to any
OSEHRA resource to be HTTPS.